### PR TITLE
Fixed `<TouchableOpacity/>` usage in the `formatMentionNode`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,22 @@ const users = [
 />
 
 const formatMentionNode = (txt, key)=> (
-  <Text key={key} style={styles.mention}>
+  <TouchableOpacity key={key}  onPress={() => {}}>
+    <Text style={styles.mention}>
       {txt}
-  </Text>
-)
+    </Text>
+  </TouchableOpacity>
+);
 
-<Text style={styles.messageText}>
-    {displayTextWithMentions(message.text, formatMentionNode)}
-</Text>
+const style = {
+  letterSpacing: 0,
+  color: '#595959',
+  paddingTop: 10
+};
+
+<View style={styles.messageText}>
+  {displayTextWithMentions(message.text, formatMentionNode, style)}
+</View>
 ```
 ## How it works 
 

--- a/src/Editor/EditorUtils.js
+++ b/src/Editor/EditorUtils.js
@@ -1,4 +1,5 @@
-import React, { Text } from 'react-native';
+import React from "react";
+import { Text } from 'react-native';
 
 /**
  * EditorUtils contains helper

--- a/src/Editor/EditorUtils.js
+++ b/src/Editor/EditorUtils.js
@@ -1,4 +1,4 @@
-import { Text } from 'react-native';
+import React, { Text } from 'react-native';
 
 /**
  * EditorUtils contains helper

--- a/src/Editor/EditorUtils.js
+++ b/src/Editor/EditorUtils.js
@@ -1,9 +1,11 @@
+import { Text } from 'react-native';
+
 /**
  * EditorUtils contains helper
  * functions for our Editor
  */
 
-export const displayTextWithMentions = (inputText, formatMentionNode) => {
+export const displayTextWithMentions = (inputText, formatMentionNode, style) => {
   /**
    * Use this function to parse mentions markup @[username](id) in the string value.
    */
@@ -17,7 +19,7 @@ export const displayTextWithMentions = (inputText, formatMentionNode) => {
       mentions.forEach((men, index) => {
         const initialStr = retLine.substring(lastIndex, men.start);
         lastIndex = men.end + 1;
-        formattedText.push(initialStr);
+        formattedText.push(<Text style={style}>{initialStr}</Text>);
         const formattedMention = formatMentionNode(
           `@${men.username}`,
           `${index}-${men.id}-${rowIndex}`
@@ -25,13 +27,13 @@ export const displayTextWithMentions = (inputText, formatMentionNode) => {
         formattedText.push(formattedMention);
         if (mentions.length - 1 === index) {
           const lastStr = retLine.substr(lastIndex); //remaining string
-          formattedText.push(lastStr);
+          formattedText.push(<Text style={style}>{lastStr}</Text>);
         }
       });
     } else {
-      formattedText.push(retLine);
+      formattedText.push(<Text style={style}>{retLine}</Text>);
     }
-    formattedText.push("\n");
+    formattedText.push(<Text style={style}>{'\n'}</Text>);
   });
   return formattedText;
 };


### PR DESCRIPTION
When i tried to use `<TouchableOpacity/>` component inside `formatMentionNode` function, mention disappears. Because react-native doesn't allow us to use TouchableOpacity inside the Text component. (Issue: https://github.com/facebook/react-native/issues/27549)

Related issue: https://github.com/mrazadar/react-native-mentions-editor/issues/23